### PR TITLE
Fix invalid constants in patterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::ascii::AsciiExt;
 #[derive(Debug)]
 struct Bom ( u8, u8, u8, u8 );
 
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,PartialEq,Eq)]
 enum Flavour {
     UCS,
     UTF,
@@ -13,7 +13,7 @@ enum Flavour {
     Unknown,
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,PartialEq,Eq)]
 enum ByteOrder {
     BigEndian,
     LittleEndian,
@@ -22,14 +22,14 @@ enum ByteOrder {
     NotApplicable
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,PartialEq,Eq)]
 enum Width {
     EightBit     = 8,
     SixteenBit   = 16,
     ThirtyTwoBit = 32
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone,Debug,PartialEq,Eq)]
 struct Descriptor (
     Flavour,
     Width,


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it's going to be broken by an upcoming bugfix in rustc. This PR adds the property of structural equality to `Descriptor` type so constants of this type can be used in patterns.
See https://github.com/rust-lang/rust/issues/36891 and rust-lang/rust#36894 for more details.
